### PR TITLE
fix: add Node-safe cache key generation

### DIFF
--- a/src/services/ApiService.js
+++ b/src/services/ApiService.js
@@ -117,7 +117,19 @@ class ApiCache {
 
   generateKey(url, options = {}) {
     const keyData = { url, method: options.method || 'GET', body: options.body };
-    return btoa(JSON.stringify(keyData));
+    const keyString = JSON.stringify(keyData);
+
+    // Use browser btoa when available, fall back to Node Buffer in non-browser environments
+    if (typeof btoa === 'function') {
+      return btoa(keyString);
+    }
+
+    if (typeof Buffer !== 'undefined') {
+      return Buffer.from(keyString).toString('base64');
+    }
+
+    // As a last resort, return the raw string (shouldn't happen in modern environments)
+    return keyString;
   }
 
   set(key, data, ttl = this.defaultTTL) {


### PR DESCRIPTION
## Summary
- avoid `btoa` ReferenceError in Node by using `Buffer` when encoding cache keys

## Testing
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6896200264108330ba044d36f0d90bc6